### PR TITLE
Restore support for older ruby versions

### DIFF
--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -71,7 +71,7 @@ module Pronto
         error: :error,
         fatal: :fatal
       }
-      severities = Pronto::ConfigFile.new.to_h.fetch('rubocop'){ {} }.fetch('severities'){ {} }
+      severities = (Pronto::ConfigFile.new.to_h['rubocop'] || {})['severities'] || {}
       severities = Hash[severities.map { |k, v| [k.to_sym, v.to_sym] }]
       default_severities.merge(severities)[severity]
     end

--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -71,7 +71,7 @@ module Pronto
         error: :error,
         fatal: :fatal
       }
-      severities = Pronto::ConfigFile.new.to_h.dig('rubocop', 'severities') || {}
+      severities = Pronto::ConfigFile.new.to_h.fetch('rubocop'){ {} }.fetch('severities'){ {} }
       severities = Hash[severities.map { |k, v| [k.to_sym, v.to_sym] }]
       default_severities.merge(severities)[severity]
     end


### PR DESCRIPTION
Replace implementation using `dig` (supported by ruby >= 2.3) with an equivalent one supporting older ruby versions.